### PR TITLE
Fixed containerOverlay for ADS_USE_CHILD_WIDGET_OVERLAY

### DIFF
--- a/src/DockManager.h
+++ b/src/DockManager.h
@@ -119,6 +119,29 @@ protected:
 	 */
 	CDockOverlay* dockAreaOverlay() const;
 
+    /**
+     * Calling proper constructor for dockAreaOverlay
+     */
+    void createNewDockAreaOverlay();
+
+    /**
+     * Calling proper constructor for containerOverlay
+     */
+    void createNewContainerOverlay();
+
+#ifdef ADS_USE_CHILD_WIDGET_OVERLAY
+
+    /**
+     * Connects to containerOverlay's destroy signal to create new Overlay after destruction
+     */
+    void connectToContainerOverlay();
+
+    /**
+     * Connects to dockAreaOverlay`s destroy signal to create new Overlay after destruction
+     */
+    void connectToDockAreaOverlay();
+
+#endif
 
 	/**
 	 * A container needs to call this function if a widget has been dropped


### PR DESCRIPTION
There was bug. Way to reproduce:
create widget in main window, than drag it to floating state
create second widget in main window, than drag it in first floating widget
close floating window with two widgets
create the same to first widget in main window again
try to drag it
SEGFAULT